### PR TITLE
Feat: 직원 부서 변경 기능 추가

### DIFF
--- a/Employee/EmployeeController.java
+++ b/Employee/EmployeeController.java
@@ -12,6 +12,7 @@ public class EmployeeController {
     private static final EmployeeUpdate employeeUpdate = new EmployeeUpdate();
     private static final EmployeeHourlyWage employeeHourlyWage = new EmployeeHourlyWage();
     private static final EmployeeProjectUpdate employeeProjectUpdate = new EmployeeProjectUpdate();
+    private static final EmployeeDeptChange employeeDeptChange = new EmployeeDeptChange();
 
     public void getController(){
         boolean flag = true;
@@ -54,6 +55,8 @@ public class EmployeeController {
         System.out.println("4. 직원 급여 인상");
         System.out.println("5. 시급 계산");
         System.out.println("6. 직원 프로젝트 업데이트");
+        System.out.println("7. 직원 부서 변경");
+
         while(flag){
             flag = false;
             System.out.println();
@@ -80,8 +83,11 @@ public class EmployeeController {
                 case "6":
                     employeeProjectUpdate.updateEmployeeProject();
                     break;
+                case "7":
+                    employeeDeptChange.changeEmployeeDept();
+                    break;
                 default:
-                    System.out.println("[도우미] 잘못된 입력입니다. 1~5사이의 숫자만 입력해주세요.");
+                    System.out.println("[도우미] 잘못된 입력입니다. 1~7사이의 숫자만 입력해주세요.");
                     flag = true;
             }
         }

--- a/Employee/EmployeeDeptChange.java
+++ b/Employee/EmployeeDeptChange.java
@@ -1,0 +1,96 @@
+package Employee;
+
+import Database.DatabaseConnection;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Scanner;
+
+public class EmployeeDeptChange {
+
+    // 부서 변경 프로그램을 시작하는 메서드
+    public void changeEmployeeDept() {
+        Scanner scanner = new Scanner(System.in);
+
+        System.out.print("부서를 변경할 직원의 SSN을 입력하세요: ");
+        String ssn = scanner.nextLine().trim();
+
+        System.out.print("이동할 부서명을 입력하세요: ");
+        String departmentName = scanner.nextLine().trim();
+
+        try {
+            if (isEmployeeInDepartment(ssn, departmentName)) {
+                System.out.printf("%s 직원은 이미 %s 부서에 속해있습니다.\n\n", getEmployeeName(ssn), departmentName);
+                return;
+            }
+
+            if (isEmployeeManager(ssn)) {
+                System.out.printf("%s 직원은 다른 부서의 매니저이므로, 타 부서로의 이동이 불가능합니다.\n\n", getEmployeeName(ssn), departmentName);
+                return;
+            }
+
+            updateEmployeeDepartment(ssn, departmentName);
+            System.out.printf("%s 직원이 성공적으로 %s 부서로 이동했습니다.\n\n", getEmployeeName(ssn), departmentName);
+
+        } catch (SQLException e) {
+            printSQLException(e);
+        }
+    }
+
+    // SSN으로 직원 이름 가져오기
+    private String getEmployeeName(String ssn) throws SQLException {
+        String name = "";
+        try (PreparedStatement pstmt = DatabaseConnection.connection.prepareStatement("SELECT Fname, Lname FROM EMPLOYEE WHERE Ssn = ?")) {
+            pstmt.setString(1, ssn);
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                name = rs.getString("Fname") + " " + rs.getString("Lname");
+            }
+        }
+        return name;
+    }
+
+    // 직원이 이미 해당 부서에 속해있는지 확인
+    private boolean isEmployeeInDepartment(String ssn, String departmentName) throws SQLException {
+        String sql = "SELECT Dname FROM DEPARTMENT d " +
+                "JOIN EMPLOYEE e ON d.Dnumber = e.Dno " +
+                "WHERE e.Ssn = ? AND d.Dname = ?";
+        try (PreparedStatement pstmt = DatabaseConnection.connection.prepareStatement(sql)) {
+            pstmt.setString(1, ssn);
+            pstmt.setString(2, departmentName);
+            ResultSet rs = pstmt.executeQuery();
+            return rs.next();
+        }
+    }
+
+    // 매니저직을 맡고 있는 직원인지 확인
+    private boolean isEmployeeManager(String ssn) throws SQLException {
+        String sql = "SELECT CASE WHEN COUNT(*) > 0 THEN 'true' ELSE 'false' END AS IsManager FROM DEPARTMENT WHERE Mgr_ssn = ?";
+
+        try (PreparedStatement pstmt = DatabaseConnection.connection.prepareStatement(sql)) {
+            pstmt.setString(1, ssn);
+            ResultSet rs = pstmt.executeQuery();
+
+            if (rs.next()) {
+                return rs.getString("IsManager").equals("true");
+            }
+        }
+        return false;
+    }
+
+    // 부서 업데이트 메소드
+    private void updateEmployeeDepartment(String ssn, String departmentName) throws SQLException {
+        String sql = "UPDATE EMPLOYEE SET Dno = (SELECT Dnumber FROM DEPARTMENT WHERE Dname = ?) WHERE Ssn = ?";
+        try (PreparedStatement pstmt = DatabaseConnection.connection.prepareStatement(sql)) {
+            pstmt.setString(1, departmentName);
+            pstmt.setString(2, ssn);
+            pstmt.executeUpdate();
+        }
+    }
+
+    // SQL 예외 처리 메시지 통합
+    private void printSQLException(SQLException ex) {
+        System.out.println("SQL 예외 발생: " + ex.getMessage());
+    }
+}


### PR DESCRIPTION
## 기능 추가
### 직원 부서 변경 기능을 EmployeeDeptChange 클래스에 작성.
- 사용자로부터 department는 부서명으로 입력받아 구분하고, employee는 ssn으로 입력하여 구분.
- 이미 해당 부서에 속한 사람을 선택했을 시, "{직원 이름} 직원은 이미 {부서명} 부서에 속해있습니다." 출력하며 즉시 기능 종료, 상단 메뉴로 돌아감.
- 특정 부서의 매니저 직책을 맡고 있는 직원의 경우, 부서 변경이 불가능토록 함. “{직원 이름} 직원은 {부서명} 직원의 매니저이므로 이적이 불가능합니다.” 출력하며 즉시 기능 종료, 상단 메뉴로 돌아감.
- 성공적으로 직원의 부서를 변경했을 시 "{직원 이름} 직원이 성공적으로 {부서명} 부서로 이동했습니다." 출력하며 즉시 기능 종료, 상단 메뉴로 돌아감
### 기능을 컨트롤러에 통합하여 적용하기 위해 EmployeeControll에 객체를 추가함.
- 콘솔에 (2), (7)입력 시 프로세스 실행
- 기능이 추가됨에 따라 일부 print문 수정